### PR TITLE
Fix iteration order docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,11 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
 
-  lint:
-    name: "Check formatting"
+  nph:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - name: Check `nph` formatting
+        uses: arnetheduck/nph-action@v1
         with:
-          fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
-
-      - name: Check nph formatting
-        # Pin nph to a specific version to avoid sudden style differences.
-        run: |
-          VERSION="v0.6.0"
-          ARCHIVE="nph-linux_x64.tar.gz"
-          curl -L "https://github.com/arnetheduck/nph/releases/download/${VERSION}/${ARCHIVE}" -o ${ARCHIVE}
-          tar -xzf ${ARCHIVE}
-          ./nph .
-          git diff --exit-code
+          version: 0.6.2

--- a/src/minilru.nim
+++ b/src/minilru.nim
@@ -55,8 +55,6 @@ type
     ##
     ## Because the "last used item" is not explicitly tracked, it's also not
     ## possible to pop it without a lengthy iteration (for a non-full cache).
-
-
     nodes: seq[LruNode[K, V]]
       ## Doubly-linked list of cached entries - 0-eth entry contains head/tail -
       ## this also allows using index 0 as a special marker for "unused" in the

--- a/tests/test_minilru.nim
+++ b/tests/test_minilru.nim
@@ -252,7 +252,7 @@ suite "minilru":
   test "MRU iteration order":
     var lru = LruCache[int, int].init(5)
 
-    for i in 0..<6:
+    for i in 0 ..< 6:
       lru.put(i, i)
 
     check:


### PR DESCRIPTION
The iteration order was wrongly described as LRU when in fact the iteration happens in MRU order and LRU order is expensive to establish in the current implementation.

To iterate in the opposite direction (and thus allow popping the least recently used item when the cache is not full), one would have to keep explicit track of where that item lives - feasible, but the cost of keeping it up to date would have to be considered.